### PR TITLE
Added input file support for ajax form post

### DIFF
--- a/jquery.unobtrusive-ajax.js
+++ b/jquery.unobtrusive-ajax.js
@@ -124,6 +124,30 @@
             options.type = "POST";
             options.data.push({ name: "X-HTTP-Method-Override", value: method });
         }
+		
+		// change here:
+		// Check for a Form POST with enctype=multipart/form-data
+		// add the input file that were not previously included in the serializeArray()
+		// set processData and contentType to false
+        var $element = $(element);
+        if ($element.is("form") && $element.attr("enctype") == "multipart/form-data") {
+            var formdata = new FormData();
+            $.each(options.data, function (i, v) {
+                formdata.append(v.name, v.value);
+            });
+            $("input[type=file]", $element).each(function () {
+                var file = this;
+                $.each(file.files, function (n, v) {
+                    formdata.append(file.name, v);
+                });
+            });
+            $.extend(options, {
+                processData: false,
+                contentType: false,
+                data: formdata
+            });
+        }
+        // end change
 
         $.ajax(options);
     }


### PR DESCRIPTION
The current version does not support uploading files as part of the POST even if jquery allows it for HTML5 enabled browsers. My approach to solve this was first, trying to modify as little as possible on the original source code. It consist of a verification for the current AJAX request being from a form and the form has set the enctype to multipart/form-data, otherwise, there is no point in trying to check for files to be uploaded. 

In case finding that it's a form with the enctype, then create a FormData instance and fill it accordingly with all previous elements already in options.data and then with all input files which are inside that form. The last part sets both processData and contentType jquery options to false as it's not required to transform anything related to content type.

I've prepared a working demo which you can find [here](https://bitbucket.org/abelperezok/mvc4apptestuploadajax).