### PR TITLE
 * Include license in bower

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -10,7 +10,8 @@
         "**/.*",
         "*.json",
         "*.md",
-        "*.txt"
+        "*.txt",
+        "!LICENSE.txt"
     ],
     "keywords": [
         "jquery",


### PR DESCRIPTION
Make the bower package include the license file. An offshoot of https://github.com/aspnet/jquery-validation-unobtrusive/issues/21