### PR TITLE
 ajax update ignored if ajax response is an object

### DIFF
--- a/src/jquery.unobtrusive-ajax.js
+++ b/src/jquery.unobtrusive-ajax.js
@@ -47,7 +47,7 @@
     function asyncOnSuccess(element, data, contentType) {
         var mode;
 
-        if (contentType.indexOf("application/x-javascript") !== -1) {  // jQuery already executes JavaScript for us
+        if (contentType.indexOf("application/x-javascript") !== -1 || $.isPlainObject(data)){  // jQuery already executes JavaScript for us
             return;
         }
 


### PR DESCRIPTION
In asyncOnSuccess it checks whether ajax response is converted to an object.
If so it ignores the ajax update codes