### PR TITLE
Add support for different request content-types

### DIFF
--- a/src/jquery.unobtrusive-ajax.js
+++ b/src/jquery.unobtrusive-ajax.js
@@ -86,6 +86,7 @@
         $.extend(options, {
             type: element.getAttribute("data-ajax-method") || undefined,
             url: element.getAttribute("data-ajax-url") || undefined,
+            contentType: element.getAttribute("data-ajax-content-type") || undefined,
             cache: (element.getAttribute("data-ajax-cache") || "").toLowerCase() === "true",
             beforeSend: function (xhr) {
                 var result;


### PR DESCRIPTION
Read "data-ajax-content-type" in order to override default request contentType.